### PR TITLE
tests: kernel: timer: starve: Adjust timeout value

### DIFF
--- a/tests/kernel/timer/starve/testcase.yaml
+++ b/tests/kernel/timer/starve/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   kernel.timer.starve:
     slow: true
-    timeout: 3600
+    timeout: 3700
     tags: kernel timer


### PR DESCRIPTION
The test in its default configuration needs 3600 seconds to complete, adjust timeout for twister to meet that.